### PR TITLE
feat: Rebrand app to stormnet and add initial subscription prompt

### DIFF
--- a/V2rayNG/app/build.gradle.kts
+++ b/V2rayNG/app/build.gradle.kts
@@ -90,7 +90,7 @@ android {
                 .map { it as com.android.build.gradle.internal.api.ApkVariantOutputImpl }
                 .forEach { output ->
                     val abi = output.getFilter("ABI") ?: "universal"
-                    output.outputFileName = "v2rayNG_${variant.versionName}-fdroid_${abi}.apk"
+                    output.outputFileName = "stormnet_${variant.versionName}-fdroid_${abi}.apk"
                     if (versionCodes.containsKey(abi)) {
                         output.versionCodeOverride =
                             (100 * variant.versionCode + versionCodes[abi]!!).plus(5000000)
@@ -110,7 +110,7 @@ android {
                     else
                         "universal"
 
-                    output.outputFileName = "v2rayNG_${variant.versionName}_${abi}.apk"
+                    output.outputFileName = "stormnet_${variant.versionName}_${abi}.apk"
                     if (versionCodes.containsKey(abi)) {
                         output.versionCodeOverride =
                             (1000000 * versionCodes[abi]!!).plus(variant.versionCode)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/MainActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/MainActivity.kt
@@ -45,6 +45,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import android.widget.EditText
 
 class MainActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedListener {
     private val binding by lazy {
@@ -175,6 +176,10 @@ class MainActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedList
         initGroupTab()
         setupViewModel()
         migrateLegacy()
+
+        if (!MmkvManager.decodeBool("sub_added", false)) {
+            showInitialSubDialog()
+        }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
@@ -656,6 +661,23 @@ class MainActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedList
 
     private fun setTestState(content: String?) {
         binding.tvTestState.text = content
+    }
+
+    private fun showInitialSubDialog() {
+        val editText = EditText(this)
+        AlertDialog.Builder(this)
+            .setTitle(R.string.initial_sub_prompt_title)
+            .setMessage(R.string.initial_sub_prompt_message)
+            .setView(editText)
+            .setPositiveButton(android.R.string.ok) { _, _ ->
+                val subLink = editText.text.toString()
+                if (subLink.isNotBlank()) {
+                    importBatchConfig(subLink)
+                    MmkvManager.encode("sub_added", true)
+                }
+            }
+            .setCancelable(false)
+            .show()
     }
 
 //    val mConnection = object : ServiceConnection {

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -8,6 +8,8 @@
     <string name="migration_success">موفقیت در انتقال داده</string>
     <string name="migration_fail">انتقال داده انجام نشد!</string>
     <string name="pull_down_to_refresh">لطفاً برای تازه کردن، پایین بکشید!</string>
+    <string name="initial_sub_prompt_title">لطفا لینک ساب دریافتی رو وارد کنید</string>
+    <string name="initial_sub_prompt_message">برای استفاده از برنامه، لینک اشتراک خود را وارد کنید</string>
 
     <!-- Notifications -->
     <string name="notification_action_stop_v2ray">توقف</string>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name" translatable="false">stormnetNG</string>
+    <string name="app_name" translatable="false">stormnet</string>
     <string name="app_widget_name">Switch</string>
     <string name="app_tile_name">Switch</string>
     <string name="app_tile_first_use">First use of this feature, please use the app to add server</string>
@@ -9,6 +9,8 @@
     <string name="migration_success">Data migration success!</string>
     <string name="migration_fail">Data migration failed!</string>
     <string name="pull_down_to_refresh">Please pull down to refresh!</string>
+    <string name="initial_sub_prompt_title">Please enter your subscription link</string>
+    <string name="initial_sub_prompt_message">To use the app, please enter your subscription link</string>
 
     <!-- Notifications -->
     <string name="notification_action_stop_v2ray">Stop</string>


### PR DESCRIPTION
- I changed the application name to "stormnet" in `strings.xml`.
- I updated the output APK file name to "stormnet" in `build.gradle.kts`.
- I added a dialog to prompt you for a subscription link on the first launch.
- The subscription link is saved as the default subscription.

Note: The build was not verified in the development environment due to a missing Android SDK. The changes are submitted with the expectation that the CI/CD pipeline will handle the build and signing.